### PR TITLE
Fix getNextMemberId for production builds

### DIFF
--- a/app/api/members/next-id/route.ts
+++ b/app/api/members/next-id/route.ts
@@ -5,10 +5,11 @@ import Member from "@/lib/models/Member";
 export async function GET() {
   try {
     await connectToDatabase();
-    const lastMember = await Member.findOne().sort({ createdAt: -1 }).lean();
-    const lastId = lastMember?.memberId ? parseInt(lastMember.memberId) : 999;
-    // return (lastId + 1).toString();
-    return NextResponse.json({ memberId: String(lastId + 1) });
+    
+    // Use the static method from the Member model
+    const nextMemberId = await Member.getNextMemberId();
+    
+    return NextResponse.json({ memberId: nextMemberId });
   } catch (error) {
     console.error("Failed to generate next member ID:", error);
     return NextResponse.json(


### PR DESCRIPTION
Fix `getNextMemberId` to work consistently in production and serverless environments.

The `getNextMemberId` static method on the Mongoose model was not reliably available in serverless production builds due to how models are cached and reused. This PR ensures the static method is always attached, centralizes the ID generation logic, and adds a pre-save hook for automatic ID generation, improving robustness.

---
<a href="https://cursor.com/background-agent?bcId=bc-654370ca-ee72-489e-abd9-493e293bd96b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-654370ca-ee72-489e-abd9-493e293bd96b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>